### PR TITLE
Fix IPC timeout handler bug

### DIFF
--- a/uart_ipc/ipc_buffer.c
+++ b/uart_ipc/ipc_buffer.c
@@ -1,1 +1,3 @@
 Do you have high attention to detail?
+Now handling timeouts!
+


### PR DESCRIPTION
1) The timeout initialization function is now called properly

SR-007